### PR TITLE
Documentation typo cleanup

### DIFF
--- a/source/how-to-contribute.rst
+++ b/source/how-to-contribute.rst
@@ -13,12 +13,12 @@ You'll find all of them on our `Katharsis Github`_ project.
 I think Katharsis should do X?
 ------------------------------
 
-If you have an idea for a new feature that Katharsis should support it is a good idea to start a discussion about it.
-You can start discussions on `Katharsis Gitter`_ or create a new issue on `Katharsis Github`_ .
+If you have an idea for a new feature that Katharsis should support, it is a good idea to start a discussion about it
+on `Katharsis Gitter`_ or create a new issue on `Katharsis Github`_ .
 
-If you also have code for the feature, definitly submit an issue and a pull request.
+If you also have code for the feature, definitely submit an issue and a pull request.
 
-Please note that it might take some time for us to answer since we are all volunteers.
+Please note that it might take some time for us to answer, since we are all volunteers.
 
 
 How development happens
@@ -34,9 +34,9 @@ We use ``development`` branch to gather new features until they are mature enoug
 As described in `git flow`_ new features are developed in features branches.
 Once a feature is complete it should get merged in ``development`` via a ``pull request`` and ``code review``.
 
-In time, features gatter and we can decide to make a new release.
-After a ``feature freaze`` period when only bug-fixes are allowed, we can release the new version of the project.
-We do this by tagging the last commit on ``development``, building binaries, publishin artifacts to Maven Central and
+In time, features gather and we can decide to make a new release.
+After a ``feature freeze`` period when only bug-fixes are allowed, we can release the new version of the project.
+We do this by tagging the last commit on ``development``, building binaries, publishing artifacts to Maven Central and
 merging development into master to prepare for the next development cycle.
 
 We use ``2.x.y`` style branches to keep maintenance versions. These version will not receive new features and are

--- a/source/how-to-update-website.rst
+++ b/source/how-to-update-website.rst
@@ -19,4 +19,4 @@ Currently the website is an Angular application.
 How to deploy changes
 ---------------------
 
-If you are a team member, you can deploy a new version oof the website.
+If you are a team member, you can deploy a new version of the website.

--- a/source/katharsis-design.rst
+++ b/source/katharsis-design.rst
@@ -12,7 +12,7 @@ It processes ``HTTP`` web requests in `json api`_ format and sends back response
 You can use it to add `json api`_ support to your web applications and build ``API``'s.
 
 Currently, you can use Katharsis to build servers and you can't use it to make requests to other `json api`_ servers.
-We are working on this featuer and it should be available in version 3.x.
+We are working on this feature and it should be available in version 3.x.
 Check https://github.com/katharsis-project/katharsis-framework/ to see the status.
 
 Concepts used by Katharsis
@@ -20,11 +20,11 @@ Concepts used by Katharsis
 
 Resource
   A ``Resource`` is a collection of attributes that users are interested in. A resource must have a unique ``type`` and ``id``.
-  Katharsis use ``JsonApiResource`` annotation to mark classes as resources.
+  Katharsis uses the ``JsonApiResource`` annotation to mark classes as resources.
 
 Repository
   A ``Repository`` is a class that implements the `repository pattern`_ . We use this class to access and manipulate ``Resource``'s
-  In Katahrsis we mark a class as being a repository by using an annotated or implement an interface.
+  In Katharsis we mark a class as being a repository by annotating it as such or by implementing an interface.
   There are resource repositories and resource relationship repositories.
   The first handles resources and the second handles relationships between two resources.
 
@@ -32,7 +32,7 @@ Repository
 How does Katharsis work?
 ------------------------
 
-When is starts, the library performs a ``bootstrap`` phase and then enters ``running`` phase.
+When is starts, the library performs a ``bootstrap`` phase and then enters the ``running`` phase.
 
 During ``bootstrap``, the library discovers resources and repositories and builds up a registry.
 It then takes the information in the ``resource registry`` and  creates instances of the repositories.
@@ -41,20 +41,20 @@ Finally, it uses uses all these to construct a ``request dispatcher``.
 
 The ``request dispatcher`` is used in the ``running`` phase to process requests and send response in `json api`_ format.
 
-Tasks performed during ``bootstrap``
+Tasks performed during ``bootstrap`` phase
 
 * resource discovery
 * repository creation
 * dispatcher creation
 
-Tasks performed during ``running``
+Tasks performed during ``running`` phase
 
 * request processing
 * resource deserialization (when reading requests)
 * resource serialization (when sending responses)
 
 .. note::
-  All these steps are defined in Java interfaces so you can customise each one of them.
+  All these steps are defined in Java interfaces for easy customisation.
 
 
 Katharsis bootstrap
@@ -166,9 +166,9 @@ Once we have created the repositories we can create the ``request dispatcher`` .
 Request dispatcher creation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The request dispatcher is the main integration point between Katharsis and any other web frameworks.
+The request dispatcher is the main integration point between Katharsis and other web frameworks.
 
-It has a single method ``handle`` thar receives the Request and builds up a ``ResponseContext``.
+It has a single method ``handle`` that receives the Request and builds up a ``ResponseContext``.
 
 .. code-block:: java
 
@@ -193,23 +193,23 @@ Request processing
 ~~~~~~~~~~~~~~~~~~
 
 Once Katharsis is up and running it will receive and process requests.
-The API is pretty simple and requries you to build a ``Request`` object that contains all the information needed.
+The API is pretty simple and requires you to build a ``Request`` object that contains all the information needed.
 
-This step is handled by katharsis integrations with frameworks like Spring or JAX-RS or Vertx so most of the time you don't need to do anything.
+This step is handled by katharsis integrations with frameworks like Spring, JAX-RS, or Vertx, so most of the time you don't need to do anything.
 
 The library does the following steps:
 
-* validates the request - it checks to see if we have the resource in the registry and can handle the request
-* it finds a proper ``JsonApiHandler`` (based on the HTTP method and request path) and delegates request processing to it
-* sends the response (to be serialized as JSON)
+* Validates the request - it checks to see if we have the resource in the registry and can handle the request.
+* Finds a proper ``JsonApiHandler`` (based on the HTTP method and request path) and delegates request processing to it.
+* Sends the response (to be serialized as JSON).
 
 Each ``JsonApiHandler`` implements a specific part of `json api`_ specification, either from `Fetching data` or from `Creating, Updating and Deleting`.
 
-The handler in turn, perfomes the following:
+The handler in turn, performs the following:
 
-* finds the resource repository or relationship repository
-* invokes the repository method and returns the result
-* optionally, depending on what is returned, it may call other repository methods to perform relationship inclusion or fill Meta Information or Links Information
+* Finds the resource repository or relationship repository.
+* Invokes the repository method and returns the result.
+* Depending on what is returned, it may call other repository methods to perform relationship inclusion or fill Meta Information or Links Information.
 
 Resource serialization and deserialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,7 +218,7 @@ These tasks require us to transform a resource (``ResponseContext``) to a json d
 We also need to be able to perform the reverse operation, from a json request body to resource.
 
 We use currently use ``Jackson`` as a serialization framework. We build a Jackson module using ``JsonApiModuleBuilder``.
-If you need to change anything about how json is serializaed or deserialzied you can look in this class.
+If you need to change anything about how json is serialized or deserialized you can look in this class.
 
 We always serialize an instance of ``JsonApiDocument``. Repositories however can respond with basic resources.
 In that case the ``JsonApiDocument`` is built by the library by wrapping the response.
@@ -232,13 +232,13 @@ There are two strategies that we consider:
 
 #. Repositories return instances of Resources
 
-  In this case we wrap the return object (instance of class annotated with ``@JsonApiResource`` ) in a ``@JsonApiDocument``.
-  The library code also takes care of calling the methdos for ``included`` resources.
+   In this case we wrap the return object (instance of class annotated with ``@JsonApiResource`` ) in a ``@JsonApiDocument``.
+   The library code also takes care of calling the methods for ``included`` resources.
 
 #. Repositories return instance of ``JsonApiDocument``
 
-  This requires users to do more work but is more efficient and can provide a much better controll over response.
-  You can customise almost all of the response, including: meta information, links, included relationships, etc.
+   This requires users to do more work but is more efficient and can provide a much better control over the response.
+   You can customize almost every aspect of the response (meta information, links, included relationships, etc.)
 
 
 .. _`json api`: http://jsonapi.org/

--- a/source/user-docs.rst
+++ b/source/user-docs.rst
@@ -7,10 +7,10 @@ Katharsis provides means to easily expose resources over the REST interface. If 
 Requirements
 ------------
 
-Below are listed dependencies used in Katharsis that project has to meet to be compatibile with latest library version:
+Below are listed dependencies used in Katharsis that project has to meet to be compatible with latest library version:
 
 .. note::
-  Katharis library requires minimum Java 7 to build and run.
+  Katharsis library requires minimum Java 7 to build and run.
 
 
 ``katharsis-core``
@@ -174,7 +174,7 @@ The example below shows a sample class which contains a definition of a field wh
 JsonApiToOne
 ~~~~~~~~~~~~
 
-Indicates an association to single value which need to be handled by a separate ``RelationshipRepository``.
+Indicates an association to single value which needs to be handled by a separate ``RelationshipRepository``.
  A type of the field has to be a valid resource.
 
 The example below shows a sample class which contains this kind of relationship.
@@ -326,8 +326,7 @@ RelationshipRepository
 Each relationship defined in Katharsis (annotation @JsonApiToOne and @JsonApiToMany) must have a relationship repository defined.
 
 Base unidirectional repository responsible for operations on relations.
-All of the methods in this interface have fieldName field as last parameter.
-It solves a problem of many relationships between the same resources.
+All of the methods in this interface have fieldName field as their last parameter to solve the problem of many relationships between the same resources.
 
 * ``setRelation(T source, D_ID targetId, String fieldName)``
   Sets a resource defined by targetId to a field fieldName in an instance source. If no value is to be set, null value is passed.
@@ -356,15 +355,14 @@ Nevertheless, it should be avoided because of potential future problems when add
 Annotated repositories
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A resource repository can be defined not by implementing ``ResourceRepository`` or ``RelationshipRepository`` interface,
-but using ``JsonApiResourceRepository`` or ``JsonApiRelationshipRepository`` annotations from ``io.katharsis.repository.annotations`` package.
+A resource repository can also be defined using the ``JsonApiResourceRepository`` or ``JsonApiRelationshipRepository`` annotations from ``io.katharsis.repository.annotations`` package.
 
 Defining the repositories this way has two benefits:
 
-* It's not needed define all of the methods i.e. read-only resources might have just reading methods defined
+* It's not necessary to define all of the methods i.e. read-only resources might have just reading methods defined
 * Additional parameters can be added to the methods like authentication, request headers or cookies
 
-Along with the required parameters for each methods (like resource identifier in ``JsonApiFindOne``) default supported type is ``QueryParams`` which provides parsed set of query parameters.
+Along with the required parameters for each methods (like the resource identifier in ``JsonApiFindOne``), the default supported type is ``QueryParams``, which provides a set of parsed query parameters.
 Each Katharsis integration provides different set of supported parameters.
 This list can be found in JAX-RS and Servlet integration sections.
 
@@ -372,23 +370,23 @@ A list below defines a mapping of ``ResourceRepository`` methods to annotations:
 
 * ``findOne(ID, QueryParams) -> JsonApiFindOne``
 
-  The first parameter has to be resource's id. The method has to return one resource.
+  The first parameter must be a resource's id. This method must return one resource.
 
 * ``findAll(QueryParams) -> JsonApiFindAll``
 
-  The method has to return a list of resources.
+  This method must return a list of resources.
 
 * ``findAll(Iterable<ID>, QueryParams) -> JsonApiFindAllWithIds``
 
-  The first parameter has to be a list of resource ids. The method has to return a list of resources.
+  The first parameter must be a list of resource ids. This method must return a list of resources.
 
 * ``save(S) -> JsonApiSave``
 
-  The first parameter has to be resource. The method has to return one resource.
+  The first parameter must be a resource. This method must return one resource.
 
 * ``delete(ID) -> JsonApiDelete``
 
-  The first parameter has to be resource's id.
+  The first parameter must be a resource's id.
 
 
 A list below defines a mapping of ``RelationshipRepository`` methods to annotations:
@@ -399,7 +397,7 @@ A list below defines a mapping of ``RelationshipRepository`` methods to annotati
 
   #. Instance of a source resource
   #. Instance of a relationship to be set
-  #. Relationship's filed name
+  #. Relationship's field name
 
 * ``setRelations(T, Iterable<D_ID>, String) -> JsonApiSetRelations``
 
@@ -407,7 +405,7 @@ A list below defines a mapping of ``RelationshipRepository`` methods to annotati
 
   #. Instance of a source resource
   #. ``Iterable`` of relationships to be set
-  #. Relationship's filed name
+  #. Relationship's field name
 
 * ``addRelations(T, Iterable<D_ID>, String) -> JsonApiAddRelation``
 
@@ -415,7 +413,7 @@ A list below defines a mapping of ``RelationshipRepository`` methods to annotati
 
   #. Instance of a source resource
   #. Iterable of relationships to be add
-  #. Relationship's filed name
+  #. Relationship's field name
 
 * ``removeRelations(T, Iterable<D_ID>, String) -> JsonApiRemoveRelation``
 
@@ -423,7 +421,7 @@ A list below defines a mapping of ``RelationshipRepository`` methods to annotati
 
   #. Instance of a source resource
   #. Iterable of relationships to be removed
-  #. Relationship's filed name
+  #. Relationship's field name
 
 * ``findOneTarget(T_ID, String, QueryParams) -> JsonApiFindOneTarget``
 
@@ -469,7 +467,7 @@ Sorting
 
 .. note::
 
-  Katharsis implementation differs form JSON API definition of sorting in order to fit standard query parameter serializing strategy and maximize effective processing of data.
+  Katharsis implementation differs from JSON API definition of sorting in order to fit standard query parameter serializing strategy and maximize effective processing of data.
 
 Sorting information for the resources can be achieved by providing ``sort`` parameter.
 The format for sorting: ``sort[ResourceType][property|operator]([property|operator])* = "value"``
@@ -511,7 +509,7 @@ Sparse Fieldsets
 
 .. note::
 
-  Katharsis implementation differs form JSON API definition of sparse field set in
+  The Katharsis implementation differs from JSON API definition of sparse field set in
   order to fit standard query parameter serializing strategy and maximize effective processing of data.
 
 Information about fields to include in the response can be achieved by providing ``fields`` parameter.
@@ -548,8 +546,8 @@ Examples:
 Error Handling
 --------------
 
-Processing errors in Katharsis can be handled by throwing an exception and providing corresponding exception mapper.
-It will define mapping to proper JSON API error response.
+Processing errors in Katharsis can be handled by throwing an exception and providing
+a corresponding exception mapper which defines mapping to a proper JSON API error response.
 
 Throwing an exception...
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -593,7 +591,7 @@ Sample exception is nothing more than a simple runtime exception:
 Class responsible for mapping the exception should:
 
 * be annotated with ExceptionMapperProvider
-* implements JsonApiExceptionMapper interface
+* implement JsonApiExceptionMapper interface
 
 Sample exception mapper:
 
@@ -624,29 +622,29 @@ Meta Information
 ----------------
 
 There is a special interface which can be added to resource repositories to provide meta information: ``io.katharsis.repository.MetaRepository``.
-It contains a single method ``MetaInformation getMetaInformation(Iterable<T> resources)`` which return meta information object that implements a marker ``interface io.katharsis.response.MetaInformation``.
+It contains a single method ``MetaInformation getMetaInformation(Iterable<T> resources)`` which return meta information object that implements the marker ``interface io.katharsis.response.MetaInformation``.
 
-If you want to add meta information along with the responses, all repositories, that is those that implement ``ResourceRepository`` and ``RelationshipRepository``, must implement ``MetaRepository``.
+If you want to add meta information along with the responses, all repositories (those that implement ``ResourceRepository`` and ``RelationshipRepository``) must implement ``MetaRepository``.
 
-When using annotated versions of repositories, a method that provides ``MetaInformation`` object should be annotated with ``JsonApiMeta`` and the first parameter of the method has to be a list of resources.
+When using annotated versions of repositories, a method that returns a ``MetaInformation`` object should be annotated with ``JsonApiMeta`` and the first parameter of the method must be a list of resources.
 
 Links Information
 -----------------
 
 There is a special interface which can be added to resource repositories to provide links information: ``io.katharsis.repository.LinksRepository``.
-It contains a single method ``LinksInformation getLinksInformation(Iterable<T> resources)`` which return links information object that implements a marker interface ``io.katharsis.response.LinksInformation``.
+It contains a single method ``LinksInformation getLinksInformation(Iterable<T> resources)`` which return links information object that implements the marker ``interface io.katharsis.response.LinksInformation``.
 
-If you want to add meta information along with the responses, all repositories, that is those that implement ``ResourceRepository`` and ``RelationshipRepository``, must implement ``LinksRepository``.
+If you want to add meta information along with the responses, all repositories (those that implement ``ResourceRepository`` and ``RelationshipRepository``), must implement ``LinksRepository``.
 
-When using annotated versions of repositories, a method that provides ``LinksInformation`` object should be annotated with ``JsonApiLinks`` and the first parameter of the method has to be a list of resources.
+When using annotated versions of repositories, a method that returns a ``LinksInformation`` object should be annotated with ``JsonApiLinks`` and the first parameter of the method has to be a list of resources.
 
 
 JAX-RS integration
 ------------------
 
-Katharsis allows integration with JAX-RS environments trough the usage of JAX-RS specification. Under the hood there is a @PreMatching filter which checks each request for JSON API processing.
+Katharsis allows integration with JAX-RS environments through the usage of JAX-RS specification. Under the hood there is a @PreMatching filter which checks each request for JSON API processing.
 
-There are several steps required to integrate Katharsis into JAX-RS application.
+There are several steps required to integrate Katharsis into a JAX-RS application.
 
 Instantiation of a JsonServiceLocator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -659,7 +657,6 @@ Katharsis require an instance of every resources repository it finds. To provide
 
 Instantiation of a KatharsisFeature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 
 Created instance of ``JsonServiceLocator`` has to be provided to new instance of ``KatharsisFeature`` along with Jackson Databind ObjectMapper.
 
@@ -678,9 +675,9 @@ All of them are defined in KatharsisProperties class:
 * ``katharsis.config.core.resource.domain``
 
   Domain name as well as protocol and optionally port number used when building links objects in responses i.e. http://katharsis.io.
-  The value cannot end with ``/``.
+  The value must not end with ``/``.
 
-* ``katharsis.config.web.path.prefix (Optional)``
+* ``katharsis.config.web.path.prefix`` (Optional)
 
   Default prefix of a URL path used in two cases:
 
@@ -717,9 +714,9 @@ There are two ways of integrating katharsis using Servlets:
 Integrating using a Servlet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To integrate katharsis using a servlet several steps are required.
-The first one is to create a class that extends ``AbstractKatharsisServlet`` and will provide required configuration to the library.
-A code below shows a sample implementation.
+To integrate Katharsis using a servlet several steps are required.
+The first one is to create a class that extends ``AbstractKatharsisServlet`` and will provide required configuration for the library.
+The code below shows a sample implementation:
 
 .. code-block:: java
 
@@ -759,8 +756,8 @@ A code below shows a sample implementation.
 
   }
 
-The newly created servlet has to be added to ``web.xml`` file or other deployment descriptor.
-A code below shows a sample ``web.xml`` file with properly defined and configured servlet
+The newly created servlet must be added to the ``web.xml`` file or to another deployment descriptor.
+The code below shows a sample ``web.xml`` file with a properly defined and configured servlet:
 
 .. code-block:: java
 
@@ -787,9 +784,9 @@ A code below shows a sample ``web.xml`` file with properly defined and configure
 Integrating using a filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To integrate katharsis using a filter several steps are required.
-The first one is to create a class that extends ``AbstractKatharsisFilter`` and will provide required configuration to the library.
-A code below shows a sample implementation.
+To integrate Katharsis using a filter, several steps are required.
+First, create a class that extends ``AbstractKatharsisFilter``, which will provide required configuration for the library.
+The code below shows a sample implementation:
 
 .. code-block:: java
 
@@ -836,10 +833,10 @@ A code below shows a sample implementation.
       }
   }
 
-The newly created filter has to be added to ``web.xml`` file or other deployment descriptor.
+The newly created filter must be added to ``web.xml`` file or other deployment descriptor.
 A code below shows a sample ``web.xml`` file with properly defined and configured filter
 
-.. code-block:: java
+.. code-block:: xml
 
   <web-app>
     <filter>
@@ -868,7 +865,7 @@ A code below shows a sample ``web.xml`` file with properly defined and configure
 Repository supported parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Servlet integration allows a developer to pass the following types of parameters in repository methods:
+Servlet integration allows the following types of parameters in repository methods:
 
 * An instance of ``ServletContext``
 * An instance of ``HttpServletRequest``
@@ -878,8 +875,8 @@ Servlet integration allows a developer to pass the following types of parameters
 Spring integration
 ------------------
 
-Katharsis provide a simple Spring Boot integration using a ``@Configuration`` annotated class ``KatharsisConfigV2``.
-Using this class the only thing needed to allow Katharsis process requests is to configure parameters.
+Katharsis provides a simple Spring Boot integration using the ``@Configuration`` annotated class ``KatharsisConfigV2``.
+Using this class, the only thing needed to allow Katharsis process requests is parameter configuration.
 An example ``application.properties`` file is presented below.
 
 .. code-block:: bash
@@ -893,7 +890,7 @@ Spring integration uses katharsis-servlet ``AbstractKatharsisFilter`` to fetch t
 Repository supported parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spring integration allows a developer to pass all of the types supported by Spring which doesn't operate on the response.
+Spring integration allows a developer to pass all of the types supported by Spring which don't operate on the response.
 
 
 Vertx integration
@@ -908,14 +905,14 @@ Katharsis provides ``Handler`` that intercepts requests and delegates them to Ka
   }
 
 
-Simple useage example that creates the handler:
+Simple usage example that creates the handler:
 
 .. code-block:: java
 
   KatharsisHandler katharsisGlue = KatharsisHandlerFactory.create(Main.class.getPackage().getName(), "/api");
   router.route("/api/*").handler(katharsisGlue);
 
-Advanced usage that shows how you can inject custom paramters in Katharsis repository methods.
+Advanced usage that shows how you can inject custom parameters in Katharsis repository methods:
 
 .. code-block:: java
 


### PR DESCRIPTION
This is my first contribution to Katharsis. I noticed a few instances of typos, formatting issues, and ambiguous wording in the Katharsis docs, and wanted to help clean some of that up. If you see any changes you disagree with, are questioning, or just want to comment, please do make line comments. I may have missed something.

Along with these changes, I have a couple of documentation-related questions:
- **What do you think about a line length limit for the documentation?** Right now, there is none, and it makes the documentation source much harder to read. I propose 80 characters, as narrower columns are much easier to read. It can be argued that this makes for slower editing, but given the infrequency with which the docs will likely change and the readability improvement, I think it's worthwhile.
- **Are we auto-publishing Javadocs as part of the build process?** I think it would be very helpful for new users of the framework and new contributors to have them easily accessible without having to build the docs themselves.
- **With regard to PRs in `katharsis-docs`, which branch should I merge against?** It seems that `master` has been updated much more recently than the others, so I made this against `master`.

I'd like to contribute to the actual framework in the future, and I have some background in Java, but I wanted to make what contributions I could to the docs first (which had the desired side-effect of forcing me to read them and learn more about Katharsis).
